### PR TITLE
fix: include reasoning token usage in chat usage

### DIFF
--- a/src/chat/services/chat-orchestration.service.spec.ts
+++ b/src/chat/services/chat-orchestration.service.spec.ts
@@ -1,0 +1,176 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, jest } from '@jest/globals';
+import { ChatOrchestrationService } from './chat-orchestration.service';
+import { MessageRole } from '../../common/dto/chat-message-input.dto';
+import type { ListResourcesResult } from '../../mcp/mcp-client.service';
+import type { OpenRouterResponse } from '../types/open-router.types';
+
+describe('ChatOrchestrationService', () => {
+  function createOpenRouterResponse(
+    content: string,
+    totalTokens: number,
+  ): OpenRouterResponse {
+    return {
+      id: `response-${totalTokens}`,
+      model: 'test-model',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant' as const, content },
+          finish_reason: 'stop' as const,
+        },
+      ],
+      usage: {
+        prompt_tokens: Math.floor(totalTokens * 0.7),
+        completion_tokens: totalTokens - Math.floor(totalTokens * 0.7),
+        total_tokens: totalTokens,
+      },
+    };
+  }
+
+  it('records document reasoning tokens together with final response tokens', async () => {
+    const finalStream = new PassThrough();
+    const listResult: ListResourcesResult = {
+      raw: {},
+      texts: ['available school documents'],
+      resourceLinks: [],
+      embeddedResources: [],
+      filteredResources: [
+        { path: '학사편람/졸업요건.md', formats: ['md'] },
+        { path: '학사편람/수강신청.md', formats: ['md'] },
+        { path: '학사편람.pdf', formats: ['pdf'] },
+      ],
+    };
+
+    const mcpClientService = {
+      withSession: jest.fn(async (fn: () => Promise<unknown>) => fn()),
+      callTool: jest.fn(async (name: string, args: { path?: string }) => {
+        if (name === 'list_resources') {
+          return listResult;
+        }
+
+        if (name === 'get_resource' && args.path === '학사편람/졸업요건') {
+          return {
+            raw: {},
+            texts: ['졸업요건 문서 본문입니다.'],
+            resourceLinks: [],
+            embeddedResources: [],
+            filteredResources: [],
+          };
+        }
+
+        if (name === 'get_resource' && args.path === '학사편람/수강신청') {
+          return {
+            raw: {},
+            texts: ['수강신청 문서 본문입니다.'],
+            resourceLinks: [],
+            embeddedResources: [],
+            filteredResources: [],
+          };
+        }
+
+        throw new Error(`Unexpected tool call: ${name}`);
+      }),
+    };
+    type CallLLM = (...args: unknown[]) => Promise<OpenRouterResponse>;
+    type RecordUsage = (
+      sessionId: string,
+      input: { totalTokens: number },
+    ) => Promise<void>;
+
+    const openRouterService = {
+      getModel: jest.fn((type: string) => `${type}-model`),
+      callLLM: jest
+        .fn<CallLLM>()
+        .mockResolvedValueOnce(createOpenRouterResponse('1, 2', 100))
+        .mockResolvedValueOnce(createOpenRouterResponse('1', 200)),
+      generateFinalResponseStream: jest.fn(async () => finalStream),
+    };
+    const chatService = {
+      getMessagesForContext: jest.fn(async () => []),
+      createMessage: jest.fn(async (_sessionId: string, dto: unknown) => ({
+        id: 'message-id',
+        ...(dto as Record<string, unknown>),
+        createdAt: new Date(),
+      })),
+    };
+    const usageService = {
+      recordUsage: jest.fn<RecordUsage>(async () => undefined),
+    };
+    const configService = {
+      get: jest.fn((key: string) =>
+        key === 'DOMAIN_NAME' ? 'example.com' : undefined,
+      ),
+    };
+
+    const service = new ChatOrchestrationService(
+      mcpClientService as never,
+      openRouterService as never,
+      chatService as never,
+      usageService as never,
+      configService as never,
+    );
+
+    let resolveEnd: () => void;
+    const responseEnded = new Promise<void>((resolve) => {
+      resolveEnd = resolve;
+    });
+    const reply = {
+      hijack: jest.fn(),
+      raw: {
+        writeHead: jest.fn(),
+        write: jest.fn(),
+        end: jest.fn(() => resolveEnd()),
+      },
+    };
+    const req = {
+      headers: { origin: 'http://localhost:5173' },
+    };
+
+    await service.handleStreamingResponse(
+      'session-id',
+      '졸업 요건 알려줘',
+      reply as never,
+      req as never,
+    );
+
+    finalStream.write(
+      `data: ${JSON.stringify({
+        model: 'heavy-model',
+        choices: [{ delta: { content: '졸업요건 답변' } }],
+      })}\n\n`,
+    );
+    finalStream.write(
+      `data: ${JSON.stringify({
+        usage: {
+          prompt_tokens: 210,
+          completion_tokens: 90,
+          total_tokens: 300,
+        },
+      })}\n\n`,
+    );
+    finalStream.end('data: [DONE]\n\n');
+
+    await responseEnded;
+
+    expect(openRouterService.callLLM).toHaveBeenCalledTimes(2);
+    expect(usageService.recordUsage).toHaveBeenCalledWith('session-id', {
+      totalTokens: 600,
+    });
+    expect(chatService.createMessage).toHaveBeenCalledWith(
+      'session-id',
+      expect.objectContaining({
+        role: MessageRole.ASSISTANT,
+        content: '졸업요건 답변',
+        metadata: expect.objectContaining({
+          model: 'heavy-model',
+          usage: {
+            prompt_tokens: 420,
+            completion_tokens: 180,
+            total_tokens: 600,
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/src/chat/services/chat-orchestration.service.ts
+++ b/src/chat/services/chat-orchestration.service.ts
@@ -12,7 +12,11 @@ import { McpClientService } from '../../mcp/mcp-client.service';
 import { OpenRouterService } from './open-router.service';
 import { ChatService } from './chat.service';
 import { UsageService } from '../../usage/usage.service';
-import type { McpTool, OpenRouterMessage } from '../types/open-router.types';
+import type {
+  McpTool,
+  OpenRouterMessage,
+  OpenRouterUsage,
+} from '../types/open-router.types';
 import { MessageRole } from '../../common/dto/chat-message-input.dto';
 import type { Readable } from 'stream';
 import type { FastifyReply, FastifyRequest } from 'fastify';
@@ -60,6 +64,37 @@ export class ChatOrchestrationService {
     private readonly usageService: UsageService,
     private readonly configService: ConfigService,
   ) {}
+
+  private createEmptyUsage(): OpenRouterUsage {
+    return {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    };
+  }
+
+  private addTokenUsage(
+    target: OpenRouterUsage | undefined,
+    usage: OpenRouterUsage | null | undefined,
+  ): void {
+    if (!target || !usage) return;
+
+    const promptTokens = usage.prompt_tokens ?? 0;
+    const completionTokens = usage.completion_tokens ?? 0;
+    const totalTokens = usage.total_tokens ?? promptTokens + completionTokens;
+
+    target.prompt_tokens += promptTokens;
+    target.completion_tokens += completionTokens;
+    target.total_tokens += totalTokens;
+  }
+
+  private hasTokenUsage(usage: OpenRouterUsage): boolean {
+    return (
+      usage.prompt_tokens > 0 ||
+      usage.completion_tokens > 0 ||
+      usage.total_tokens > 0
+    );
+  }
 
   /**
    * MCP Tool 목록을 가져오거나 캐시에서 반환
@@ -232,6 +267,7 @@ export class ChatOrchestrationService {
     question: string,
     resources: ListResourceItem[],
     maxResults: number = 10,
+    tokenUsage?: OpenRouterUsage,
   ): Promise<string[]> {
     if (!resources?.length) {
       return [];
@@ -253,6 +289,7 @@ export class ChatOrchestrationService {
         this.openRouterService.getModel('light'),
         { temperature: 0.1, max_tokens: 5000 },
       );
+      this.addTokenUsage(tokenUsage, response.usage);
 
       let selectedText = response.choices[0]?.message?.content?.trim() || '';
       this.logger.debug(`LLM chunk selection raw: ${selectedText}`);
@@ -289,6 +326,7 @@ export class ChatOrchestrationService {
     question: string,
     resources: Array<{ path: string; formats?: string[] }>,
     maxResults: number = 10,
+    tokenUsage?: OpenRouterUsage,
   ): Promise<Array<{ path: string; formats?: string[] }>> {
     if (!resources.length) {
       return [];
@@ -311,6 +349,7 @@ export class ChatOrchestrationService {
         this.openRouterService.getModel('light'),
         { temperature: 0.1, max_tokens: 200 },
       );
+      this.addTokenUsage(tokenUsage, response.usage);
 
       const selectedText = response.choices[0]?.message?.content?.trim() || '';
       this.logger.debug(`LLM selected resource paths: ${selectedText}`);
@@ -573,6 +612,7 @@ export class ChatOrchestrationService {
   private async selectMostRelevantDocuments(
     question: string,
     documents: Array<{ title: string; content: string; path: string }>,
+    tokenUsage?: OpenRouterUsage,
   ): Promise<Array<{ title: string; content: string; path: string }>> {
     if (documents.length === 0) {
       return [];
@@ -621,6 +661,7 @@ export class ChatOrchestrationService {
         this.openRouterService.getModel('normal'),
         { temperature: 0.1, max_tokens: 100 },
       );
+      this.addTokenUsage(tokenUsage, response.usage);
 
       const selectedText = response.choices[0]?.message?.content?.trim() || '';
       this.logger.debug(`LLM selected documents: ${selectedText}`);
@@ -670,6 +711,7 @@ export class ChatOrchestrationService {
     question: string,
     resources: ListResourceItem[],
     catalogChunks?: Array<{ path: string }>,
+    tokenUsage?: OpenRouterUsage,
   ): Promise<{
     content: string;
     usedResources: Array<{ path: string; formats: string[] }>;
@@ -683,6 +725,7 @@ export class ChatOrchestrationService {
       question,
       resources,
       10,
+      tokenUsage,
     );
     this.logger.log(
       `[PERF] selectRelevantChunkPaths(LLM): ${Date.now() - t0}ms`,
@@ -738,6 +781,7 @@ export class ChatOrchestrationService {
         content: doc.content,
         path: doc.path,
       })),
+      tokenUsage,
     );
     this.logger.log(
       `[PERF] selectMostRelevantDocuments(LLM, 신 형식): ${Date.now() - t0}ms`,
@@ -806,6 +850,7 @@ export class ChatOrchestrationService {
   private async fetchRelevantResourceContents(
     question: string,
     listResult: ListResourcesResult,
+    tokenUsage?: OpenRouterUsage,
   ): Promise<{
     content: string;
     usedResources: Array<{ path: string; formats: string[] }>;
@@ -821,6 +866,7 @@ export class ChatOrchestrationService {
         question,
         listResult.resources!,
         listResult.chunks,
+        tokenUsage,
       );
     }
 
@@ -847,6 +893,7 @@ export class ChatOrchestrationService {
       question,
       mdResources,
       10,
+      tokenUsage,
     );
     this.logger.log(
       `[PERF] selectRelevantResourcePaths(LLM, 구 형식): ${Date.now() - t0}ms`,
@@ -925,6 +972,7 @@ export class ChatOrchestrationService {
         content: doc.content,
         path: doc.path,
       })),
+      tokenUsage,
     );
     this.logger.log(
       `[PERF] selectMostRelevantDocuments(LLM, 구 형식): ${Date.now() - t0}ms`,
@@ -1163,8 +1211,10 @@ export class ChatOrchestrationService {
   ): Promise<{
     stream: Readable;
     resources: ResourceInfo[];
+    usage: OpenRouterUsage;
   }> {
     const perfTurnStart = Date.now();
+    const usage = this.createEmptyUsage();
 
     try {
       // 0. 과거 대화 조회 (현재 user 저장 전 → 직전 대화까지 context)
@@ -1223,7 +1273,7 @@ export class ChatOrchestrationService {
           this.openRouterService.getModel('normal'),
           { temperature: 0 },
         );
-        return { stream, resources: [] };
+        return { stream, resources: [], usage };
       }
 
       // 3. 관련 리소스 내용 가져오기 (신 형식: description 기반 chunk 선별 / 구 형식: 경로 선별 후 본문 fetch)
@@ -1231,6 +1281,7 @@ export class ChatOrchestrationService {
       const relevantResult = await this.fetchRelevantResourceContents(
         userQuestion,
         listResult,
+        usage,
       );
       this.logger.log(
         `[PERF] fetchRelevantResourceContents: ${Date.now() - t0}ms`,
@@ -1252,7 +1303,7 @@ export class ChatOrchestrationService {
           this.openRouterService.getModel('normal'),
           { temperature: 0 },
         );
-        return { stream, resources: [] };
+        return { stream, resources: [], usage };
       }
 
       const resultText =
@@ -1372,7 +1423,7 @@ export class ChatOrchestrationService {
         `[PERF] processUserQuestionStream 전체: ${Date.now() - perfTurnStart}ms`,
       );
 
-      return { stream, resources: allResources };
+      return { stream, resources: allResources, usage };
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -1422,17 +1473,17 @@ export class ChatOrchestrationService {
     });
 
     try {
-      const { stream, resources } = await this.mcpClientService.withSession(
-        () => this.processUserQuestionStream(sessionId, userQuestion),
+      const {
+        stream,
+        resources,
+        usage: reasoningUsage,
+      } = await this.mcpClientService.withSession(() =>
+        this.processUserQuestionStream(sessionId, userQuestion),
       );
 
       let accumulatedContent = '';
       let model = '';
-      let usage: {
-        prompt_tokens: number;
-        completion_tokens: number;
-        total_tokens: number;
-      } | null = null;
+      let finalResponseUsage: OpenRouterUsage | null = null;
       let buffer = '';
 
       stream.on('data', (chunk: Buffer) => {
@@ -1458,7 +1509,7 @@ export class ChatOrchestrationService {
                 model = parsed.model;
               }
               if (parsed.usage) {
-                usage = parsed.usage;
+                finalResponseUsage = parsed.usage;
               }
             } catch {
               // JSON 파싱 실패 시 무시
@@ -1478,13 +1529,19 @@ export class ChatOrchestrationService {
       stream.on('end', () => {
         void (async () => {
           try {
+            const totalUsage = { ...reasoningUsage };
+            this.addTokenUsage(totalUsage, finalResponseUsage);
+            const usage = this.hasTokenUsage(totalUsage)
+              ? totalUsage
+              : undefined;
+
             if (accumulatedContent) {
               await this.chatService.createMessage(sessionId, {
                 role: MessageRole.ASSISTANT,
                 content: accumulatedContent,
                 metadata: {
                   model: model || undefined,
-                  usage: usage || undefined,
+                  usage,
                   resources: resources.length > 0 ? resources : undefined,
                 },
               });

--- a/src/chat/services/open-router.service.ts
+++ b/src/chat/services/open-router.service.ts
@@ -390,6 +390,7 @@ ${params}`;
       temperature: options?.temperature ?? 0.7,
       max_tokens: 2000,
       stream: true,
+      stream_options: { include_usage: true },
     };
 
     const requestLogSummary = {

--- a/src/chat/types/open-router.types.ts
+++ b/src/chat/types/open-router.types.ts
@@ -64,6 +64,15 @@ export interface OpenRouterRequest {
   temperature?: number;
   max_tokens?: number;
   stream?: boolean;
+  stream_options?: {
+    include_usage?: boolean;
+  };
+}
+
+export interface OpenRouterUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
 }
 
 /**
@@ -77,11 +86,7 @@ export interface OpenRouterResponse {
     message: OpenRouterMessage;
     finish_reason: 'stop' | 'length' | 'tool_calls' | null;
   }>;
-  usage?: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
+  usage?: OpenRouterUsage;
 }
 
 /**


### PR DESCRIPTION
## Summary
- 문서 탐색과 선별 과정에서 발생하는 OpenRouter usage를 누적하도록 수정
- 최종 답변 스트리밍 usage와 reasoning usage를 더해 message metadata와 usage_daily에 기록
- 스트리밍 응답에서 usage 받는 stream_options.include_usage 추가
- reasoning usage + final response usage 합산 검증용 단위 테스트 추가

## Verification
- bunx tsc --noEmit --pretty false
- bun run test --runInBand
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * AI 모델 호출 시 토큰 사용량을 누적하여 정확하게 추적하고 기록하는 기능 추가
  * 스트리밍 응답에서 사용량 정보를 포함하여 상세한 통계 수집 개선

* **Tests**
  * 스트리밍 응답 처리 및 토큰 사용량 누적에 대한 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsainfoteam/chatbot-be/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->